### PR TITLE
[이주형] 2025.07.15 학습내역

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -73,10 +73,10 @@ timer_calibrate (void) {
 /* Returns the number of timer ticks since the OS booted. */
 int64_t
 timer_ticks (void) {
-	enum intr_level old_level = intr_disable ();
-	int64_t t = ticks;
-	intr_set_level (old_level);
-	barrier ();
+	enum intr_level old_level = intr_disable (); 	// 인터럽트 비활성화
+	int64_t t = ticks; 								// 틱 설정
+	intr_set_level (old_level); 					// 인터럽트 설정 ? 비설정 현재는 해제
+	barrier (); 									// 배리어 이전의 모든 메모리 읽기/쓰기 작업이 배리어 이후의 작업보다 먼저 완료됨
 	return t;
 }
 
@@ -84,17 +84,23 @@ timer_ticks (void) {
    should be a value once returned by timer_ticks(). */
 int64_t
 timer_elapsed (int64_t then) {
-	return timer_ticks () - then;
+	return timer_ticks () - then;					// 경과된 시간
 }
 
 /* Suspends execution for approximately TICKS timer ticks. */
+/*
+필요 수정 사항
+현재 스레드를 ready_list가 아닌 sleep_list에 넣어준다.
+sleep_list에 넣을 때 스레드 block
+*/
 void
 timer_sleep (int64_t ticks) {
-	int64_t start = timer_ticks ();
+	// int64_t start = timer_ticks ();
 
-	ASSERT (intr_get_level () == INTR_ON);
-	while (timer_elapsed (start) < ticks)
-		thread_yield ();
+	// ASSERT (intr_get_level () == INTR_ON);			// 인터럽트가 켜진 상태
+	// while (timer_elapsed (start) < ticks)
+	// 	thread_yield ();								// 현재 스레드를 다시 스케줄러에 넣어주는 함수
+	thread_sleep(ticks);								// 이렇게 할거면 아예 thread_sleep만 쓰는게 낫지 않나? 싶음...
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -120,12 +126,18 @@ void
 timer_print_stats (void) {
 	printf ("Timer: %"PRId64" ticks\n", timer_ticks ());
 }
-
+
 /* Timer interrupt handler. */
+/*
+필요 수정 사항
+interrupt된 스레드들 아이들 tick 증가 필요
+wake up time 도달시 block을 해제
+*/
 static void
 timer_interrupt (struct intr_frame *args UNUSED) {
-	ticks++;
-	thread_tick ();
+	ticks++;					// 전역 시간 1증가
+	thread_wakeup(ticks);		// 스레드 깨우기
+	thread_tick ();				// 현재 스레드 아이들 tick 증가
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,6 +91,7 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int64_t wakeup_time;				// 일어날 시간 추가
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -91,7 +92,12 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int original_priority;
 	int64_t wakeup_time;				// 일어날 시간 추가
+	struct list donations;				// 도네이션 리스트
+	struct list_elem donation_elem;
+	struct lock *wait_on_lock;				// 대기중인 락
+
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
@@ -143,5 +149,11 @@ int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
+
+bool thread_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED);
+bool thread_compare_donate_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED);
+void donate();
+void recalc_priority();
+void remove_lock(struct lock *lock);
 
 #endif /* threads/thread.h */

--- a/pintos/threads/interrupt.c
+++ b/pintos/threads/interrupt.c
@@ -155,6 +155,10 @@ intr_disable (void) {
 	   See [IA32-v2b] "CLI" and [IA32-v3a] 5.8.1 "Masking Maskable
 	   Hardware Interrupts". */
 	asm volatile ("cli" : : : "memory");
+	/*
+	x86 아키텍처에서는 `CLI` (Clear Interrupt Flag) 명령어 사용
+	ARM에서는 `CPSID I` (Change Processor State, Interrupt Disable) 사용
+	*/
 
 	return old_level;
 }
@@ -268,7 +272,7 @@ intr_yield_on_return (void) {
 	ASSERT (intr_context ());
 	yield_on_return = true;
 }
-
+
 /* 8259A Programmable Interrupt Controller. */
 
 /* Every PC has two 8259A Programmable Interrupt Controller (PIC)

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -41,6 +41,7 @@
 
    - up or "V": increment the value (and wake up one waiting
    thread, if any). */
+// 세마포어 초기화
 void
 sema_init (struct semaphore *sema, unsigned value) {
 	ASSERT (sema != NULL);
@@ -57,6 +58,8 @@ sema_init (struct semaphore *sema, unsigned value) {
    interrupts disabled, but if it sleeps then the next scheduled
    thread will probably turn interrupts back on. This is
    sema_down function. */
+
+// 세마포어 숫자 감소, 접근 하나 들어옴, 대기열 마지막에 추가
 void
 sema_down (struct semaphore *sema) {
 	enum intr_level old_level;
@@ -66,7 +69,8 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		// list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, thread_compare_priority, NULL); // waiter에 우선순위 기준으로 삽입
 		thread_block ();
 	}
 	sema->value--;
@@ -78,6 +82,7 @@ sema_down (struct semaphore *sema) {
    decremented, false otherwise.
 
    This function may be called from an interrupt handler. */
+// 세마포어 value가 감소하면 success 반환하여 성공여부 알려줌
 bool
 sema_try_down (struct semaphore *sema) {
 	enum intr_level old_level;
@@ -102,6 +107,8 @@ sema_try_down (struct semaphore *sema) {
    and wakes up one thread of those waiting for SEMA, if any.
 
    This function may be called from an interrupt handler. */
+
+// 락이 해제되고 나갈때
 void
 sema_up (struct semaphore *sema) {
 	enum intr_level old_level;
@@ -109,10 +116,13 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
+	if (!list_empty (&sema->waiters)){
+		list_sort (&sema->waiters, thread_compare_priority, 0); // waiter에 있는 동안 순위가 변경돼었을수도 있으므로 정렬
 		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+					struct thread, elem)); // 락 대기중인 리스트에 가장 앞을 제거하고 block 해제
+	}
 	sema->value++;
+	thread_yield(); // 선점위해 양보, 아오 일드 쌤
 	intr_set_level (old_level);
 }
 
@@ -150,7 +160,7 @@ sema_test_helper (void *sema_) {
 		sema_up (&sema[1]);
 	}
 }
-
+
 /* Initializes LOCK.  A lock can be held by at most a single
    thread at any given time.  Our locks are not "recursive", that
    is, it is an error for the thread currently holding a lock to
@@ -166,6 +176,8 @@ sema_test_helper (void *sema_) {
    acquire and release it.  When these restrictions prove
    onerous, it's a good sign that a semaphore should be used,
    instead of a lock. */
+
+// 락 초기화, 현재 락을 잡고 있는 쓰레드는 없고 세마포어 value를 1로 설정하여 하나의 쓰레드만 들어올 수 있게 함
 void
 lock_init (struct lock *lock) {
 	ASSERT (lock != NULL);
@@ -182,14 +194,31 @@ lock_init (struct lock *lock) {
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
+
+// 락 획득, 영역이 lock이 된 상태가 아니라면 현재 쓰레드에게 할당해주고 세마포어 value 1감소
 void
 lock_acquire (struct lock *lock) {
+	/*
+	증여자들을 우선순위에 따라 정렬
+	*/
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 
+	struct thread *cur = thread_current ();
+	// 어떤 스레드가 락을 가지고 있다면 락 대기
+	if (lock->holder != NULL) {
+		cur->wait_on_lock = lock;
+		// 증여자 리스트에 우선순위 기준 삽입
+		list_insert_ordered(&lock->holder->donations, &cur->donation_elem, thread_compare_donate_priority, NULL);
+		// 우선순위 기부
+		donate();
+	}
+
+	// 락을 현재 스레드에 할당
 	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	cur->wait_on_lock = NULL;
+	lock->holder = cur;
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -217,10 +246,17 @@ lock_try_acquire (struct lock *lock) {
    An interrupt handler cannot acquire a lock, so it does not
    make sense to try to release a lock within an interrupt
    handler. */
+
+// 쓰레드가 종료 후 lock 해제
 void
 lock_release (struct lock *lock) {
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
+
+	// 락 제거
+	remove_lock(lock);
+	// 우선순위 다시 계산
+	recalc_priority();
 
 	lock->holder = NULL;
 	sema_up (&lock->semaphore);
@@ -235,7 +271,7 @@ lock_held_by_current_thread (const struct lock *lock) {
 
 	return lock->holder == thread_current ();
 }
-
+
 /* One semaphore in a list. */
 struct semaphore_elem {
 	struct list_elem elem;              /* List element. */
@@ -272,6 +308,20 @@ cond_init (struct condition *cond) {
    interrupt handler.  This function may be called with
    interrupts disabled, but interrupts will be turned back on if
    we need to sleep. */
+
+bool 
+sema_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED)
+{
+	struct semaphore_elem *a_sema = list_entry (a, struct semaphore_elem, elem);
+	struct semaphore_elem *b_sema = list_entry (b, struct semaphore_elem, elem);
+
+	struct list *waiter_a_sema = &(a_sema->semaphore.waiters);
+	struct list *waiter_b_sema = &(b_sema->semaphore.waiters);
+
+	return list_entry (list_begin (waiter_a_sema), struct thread, elem)->priority
+		 > list_entry (list_begin (waiter_b_sema), struct thread, elem)->priority;
+}
+
 void
 cond_wait (struct condition *cond, struct lock *lock) {
 	struct semaphore_elem waiter;
@@ -282,7 +332,8 @@ cond_wait (struct condition *cond, struct lock *lock) {
 	ASSERT (lock_held_by_current_thread (lock));
 
 	sema_init (&waiter.semaphore, 0);
-	list_push_back (&cond->waiters, &waiter.elem);
+	// list_push_back (&cond->waiters, &waiter.elem);
+	list_insert_ordered (&cond->waiters, &waiter.elem, sema_compare_priority, NULL);
 	lock_release (lock);
 	sema_down (&waiter.semaphore);
 	lock_acquire (lock);
@@ -302,9 +353,11 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
+	if (!list_empty (&cond->waiters)){
+		list_sort(&cond->waiters, sema_compare_priority, NULL);
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
+	}
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -211,7 +211,16 @@ thread_create (const char *name, int priority,
 	t->tf.eflags = FLAG_IF;
 
 	/* Add to run queue. */
-	thread_unblock (t);
+	if (thread_current()->priority > t->priority){
+		// 큐에 추가만
+		thread_unblock (t);
+	}
+	else {
+		// 새로운 스레드 우선순위가 높다면 실행
+		// 큐에 추가 후 현재 스레드를 준비 상태로
+		thread_unblock (t);
+		thread_yield();
+	}
 
 	return tid;
 }
@@ -301,6 +310,7 @@ thread_exit (void) {
 
 /* Yields the CPU.  The current thread is not put to sleep and
    may be scheduled again immediately at the scheduler's whim. */
+// 현재 스레드를 대기 큐에 넣어주는 함수
 void
 thread_yield (void) {
 	struct thread *curr = thread_current ();
@@ -363,7 +373,15 @@ thread_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNU
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	// 우선순위가 바뀌면 더 높은 우선순위의 스레드가 실행되도록 한다.
+	struct thread *cur = thread_current ();
+	
+	cur->priority = new_priority;
+	int fisrt_priority = list_entry(list_front (&ready_list), struct thread, elem)->priority; // 준비중인 스레드중 가장 높은 우선순위 가져옴
+
+	if (fisrt_priority > new_priority){
+		thread_yield();
+	}
 }
 
 /* Returns the current thread's priority. */
@@ -516,8 +534,8 @@ do_iret (struct intr_frame *tf) {
    added at the end of the function. */
 static void
 thread_launch (struct thread *th) {
-	uint64_t tf_cur = (uint64_t) &running_thread ()->tf;
-	uint64_t tf = (uint64_t) &th->tf;
+	uint64_t tf_cur = (uint64_t) &running_thread ()->tf; 	// 현재 실행중인 스레드의 프레임을 가져온다.
+	uint64_t tf = (uint64_t) &th->tf;						// 받아온 스레드 프레임을 가져온다.
 	ASSERT (intr_get_level () == INTR_OFF);
 
 	/* The main switching logic.

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -377,10 +377,13 @@ thread_set_priority (int new_priority) {
 	struct thread *cur = thread_current ();
 	
 	cur->priority = new_priority;
-	int fisrt_priority = list_entry(list_front (&ready_list), struct thread, elem)->priority; // 준비중인 스레드중 가장 높은 우선순위 가져옴
+	// 준비 큐가 비어있지 않다면
+	if (!list_empty(&ready_list)){
+		int fisrt_priority = list_entry(list_front (&ready_list), struct thread, elem)->priority; // 준비중인 스레드중 가장 높은 우선순위 가져옴
 
-	if (fisrt_priority > new_priority){
-		thread_yield();
+		if (fisrt_priority > new_priority){
+			thread_yield();
+		}
 	}
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -370,13 +370,84 @@ thread_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNU
 	return thread_a->priority > thread_b->priority;
 }
 
+bool
+thread_compare_donate_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED)
+{
+	struct thread *thread_a = list_entry(a, struct thread, donation_elem);
+	struct thread *thread_b = list_entry(b, struct thread, donation_elem);
+	return thread_a->priority > thread_b->priority;
+}
+
+/*
+동작과정 정리
+Pintos 기본적으로 RR방식이며 이걸 priority기반으로 동작함
+현재 쓰레드가 락을 생성, 작업 중 타임을 모두 소진하면 다시 준비 큐로 되돌아감
+그 뒤에 새로운 쓰레드가 실행상태로 진입하게 되며 락 획득을 요청하게 됨
+만약 이때 처리하고 싶은 영역에 대해 락을 다른 쓰레드가 가지고 있다면
+자신보다 우선순위가 낮은 상태 따라서 낮은 우선순위와 락을 가지고 있는 쓰레드를 먼저 처리하기위해
+우선순위를 기부할 필요가 생김
+
+아래 donate 코드는 현재 생성된 쓰레드가 락을 요청하면서 실행됨
+즉, donation리스트 기준으로 가장 뒤에 삽입된 쓰레드
+현재 쓰레드가 락을 가진 애들을 보면서 앞으로 진행하면 최종적으로 처음 락을 가진 쓰레드를 만나고
+우선순위를 기부하면서 종료됨
+*/
+
+// 락 획득 요청시 실행
+void donate(){
+	struct thread *cur = thread_current();
+	struct thread *holder = cur->wait_on_lock->holder;
+
+	// holder들을 보면서 우선순위 기부
+	while (holder != NULL && holder->priority < cur->priority) {
+        holder->priority = cur->priority;
+        if (holder->wait_on_lock == NULL) break;
+        holder = holder->wait_on_lock->holder;
+    }
+}
+
+void recalc_priority(){
+	struct thread *cur = thread_current();
+
+	cur->priority = cur->original_priority;
+
+	if (!list_empty (&cur->donations)) {
+    list_sort (&cur->donations, thread_compare_donate_priority, 0);
+
+    struct thread *front = list_entry (list_front (&cur->donations), struct thread, donation_elem);
+    if (front->priority > cur->priority)
+      cur->priority = front->priority;
+  }
+}
+
+
+void
+remove_lock(struct lock *lock){
+	/*
+	현재 쓰레드를 종료하면 우선순위와 증여자 목록 삭제
+	*/
+	struct list_elem *e, *next;
+	struct thread *cur = thread_current();
+	
+    for (e = list_begin(&cur->donations); e != list_end(&cur->donations); e = list_next(e)){
+    struct thread *t = list_entry(e, struct thread, donation_elem);
+    if (t->wait_on_lock == lock){
+        list_remove(&t->donation_elem);
+    }
+}
+}
+
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
 	// 우선순위가 바뀌면 더 높은 우선순위의 스레드가 실행되도록 한다.
 	struct thread *cur = thread_current ();
 	
-	cur->priority = new_priority;
+	cur->original_priority = new_priority;
+
+	// 우선순위 재계산
+	recalc_priority();
+
 	// 준비 큐가 비어있지 않다면
 	if (!list_empty(&ready_list)){
 		int fisrt_priority = list_entry(list_front (&ready_list), struct thread, elem)->priority; // 준비중인 스레드중 가장 높은 우선순위 가져옴
@@ -481,7 +552,10 @@ init_thread (struct thread *t, const char *name, int priority) {
 	strlcpy (t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t) t + PGSIZE - sizeof (void *);
 	t->priority = priority;
+	t->original_priority = priority; 	// 기존 우선순위 저장용(불변)
 	t->magic = THREAD_MAGIC;
+	list_init(&t->donations); 			// 리스트 초기화
+	t->wait_on_lock = NULL; 			// 초기화, 대기중인 락 없음
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -27,6 +27,7 @@
 /* List of processes in THREAD_READY state, that is, processes
    that are ready to run but not actually running. */
 static struct list ready_list;
+static struct list sleep_list; // 인터럽트된 스레드 보관할 리스트
 
 /* Idle thread. */
 static struct thread *idle_thread;
@@ -62,6 +63,10 @@ static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
+void thread_sleep (int64_t ticks);
+void thread_wakeup (int64_t ticks);
+bool thread_compare_wakeup_time (struct list_elem *a, struct list_elem *b, void *aux UNUSED);
+bool thread_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -108,6 +113,7 @@ thread_init (void) {
 	/* Init the globla thread context */
 	lock_init (&tid_lock);
 	list_init (&ready_list);
+	list_init (&sleep_list); // 리스트 초기화
 	list_init (&destruction_req);
 
 	/* Set up a thread structure for the running thread. */
@@ -151,7 +157,7 @@ thread_tick (void) {
 
 	/* Enforce preemption. */
 	if (++thread_ticks >= TIME_SLICE)
-		intr_yield_on_return ();
+		intr_yield_on_return ();		// 인터럽트 복귀시 스케줄링 실행
 }
 
 /* Prints thread statistics. */
@@ -240,7 +246,8 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
-	list_push_back (&ready_list, &t->elem);
+	// list_push_back (&ready_list, &t->elem);
+	list_insert_ordered(&ready_list, &t->elem, thread_compare_priority, NULL); // 우선 순위를 기준으로 삽입되도록 변경
 	t->status = THREAD_READY;
 	intr_set_level (old_level);
 }
@@ -303,9 +310,54 @@ thread_yield (void) {
 
 	old_level = intr_disable ();
 	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+		// list_push_back (&ready_list, &curr->elem);
+		list_insert_ordered(&ready_list, &curr->elem, thread_compare_priority, NULL); // 우선 순위를 기준으로 삽입되도록 변경
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
+}
+
+// thread를 대기 상태로 만들어 주는 함수
+void
+thread_sleep (int64_t ticks) {
+	struct thread *curr = thread_current ();
+	enum intr_level old_level;
+
+	// ASSERT (!intr_context ());
+	old_level = intr_disable ();
+	curr->wakeup_time = timer_ticks() + ticks; 	// 일어날 시간
+
+	list_insert_ordered (&sleep_list, &curr->elem, thread_compare_wakeup_time, NULL);
+
+	thread_block();								// Block
+	intr_set_level(old_level); 					// 인터럽트 복원
+}
+
+// 현재 스레드를 깨우는 함수
+void
+thread_wakeup (int64_t ticks) {
+	while(!list_empty(&sleep_list)){
+		// list_entry (리스트 next ptr, offsetof(struct, member.next), 타입)
+		struct thread *p = list_entry(list_front(&sleep_list), struct thread, elem);
+		if (p->wakeup_time > ticks)
+            break;
+
+        list_pop_front(&sleep_list);
+        thread_unblock(p);
+	}
+}
+
+bool
+thread_compare_wakeup_time (struct list_elem *a, struct list_elem *b, void *aux UNUSED) {
+	struct thread *thread_a = list_entry(a, struct thread, elem);
+	struct thread *thread_b = list_entry(b, struct thread, elem);
+	return thread_a->wakeup_time < thread_b->wakeup_time;
+}
+
+bool
+thread_compare_priority (struct list_elem *a, struct list_elem *b, void *aux UNUSED) {
+	struct thread *thread_a = list_entry(a, struct thread, elem);
+	struct thread *thread_b = list_entry(b, struct thread, elem);
+	return thread_a->priority > thread_b->priority;
 }
 
 /* Sets the current thread's priority to NEW_PRIORITY. */


### PR DESCRIPTION
# [25.07.15] Priority Inversion(donation) 구현
## 주요 구현 사항
우선순위 역전 해결을 위한 도네이션 기능 구현

### 함수 구현/변경 사항
struct thread: struct list donations; struct list_elem donation_elem; struct lock *wait_on_lock; 필드 추가
donate(): 현재 쓰레드의 락 홀더를 탐색하면서 우선순위를 변경해주는 함수 구현
recalc_priority(): 우선순위 재계산 함수
remove_lock(): 락을 해제하고 증여자 삭제

sema_up, down, cond_wait, signal을 우선순위에 맞춰 동작하도록 수정


## 구현 결과
모든 priority test case 완료
<img width="322" height="169" alt="image" src="https://github.com/user-attachments/assets/d6766eaa-96d8-4930-a986-9be6afe7cda9" />

## 진행 예정
mlfq 구현 예정